### PR TITLE
Revert "fix: temporary patch for 220"

### DIFF
--- a/src/path/sentry_path_windows.c
+++ b/src/path/sentry_path_windows.c
@@ -263,7 +263,6 @@ sentry__path_remove_all(const sentry_path_t *path)
     }
     size_t path_len = wcslen(path->path);
     wchar_t *pp = sentry_malloc(sizeof(wchar_t) * (path_len + 2));
-    wcscpy(pp, path->path); // Keyman: see https://github.com/getsentry/sentry-native/issues/220
     pp[path_len] = '\0';
     pp[path_len + 1] = '\0';
     SHFILEOPSTRUCTW shfo = { NULL, FO_DELETE, pp, L"",


### PR DESCRIPTION
Reverts keymanapp/sentry-native#2

This prepares us for 0.2.3 build.